### PR TITLE
fix: support transparent as project color

### DIFF
--- a/src/dida365/models/project.py
+++ b/src/dida365/models/project.py
@@ -112,7 +112,7 @@ class ProjectBase(BaseApiModel, SortableMixin):
             v = f"#{v}"
         
         # Basic hex color validation
-        if not (len(v) == 7 and all(c in "0123456789ABCDEFabcdef#" for c in v)):
+        if not ((len(v) == 7 and all(c in "0123456789ABCDEFabcdef#" for c in v)) or v == '#transparent'):
             raise ValueError(
                 f"Invalid color hex code '{v}'. "
                 "Must be a 6-digit hex code with optional '#' prefix (e.g., '#FF0000' or 'FF0000')"


### PR DESCRIPTION
Hi I found that when I have a project without color I will get error of "color hex code" using get_projects, so I change one line of code to fix it